### PR TITLE
put back the contribution guide and note in README

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,30 @@
+Contributing
+============
+All contributions are welcome to be submitted for review for inclusion, but before they will be accepted, we ask that
+you follow these simple guidelines:
+
+
+Legal
+-----
+When submitting a PR for the first time you will be asked to agree to the Contributor License Agreement. This agreement
+is required for contributions to be accepted.
+
+
+Code Style
+----------
+When submitting code, please make every effort to follow existing conventions and style in order to keep the code as
+readable as possible. We realize that the style used in this project might be different that what is used in your
+projects, but in the end it makes it easier to merge changes and maintain in the future.
+
+
+Testing
+-------
+We kindly ask that all new features and fixes for an issue should include any unit tests. Even if it is small
+improvement, adding a unit test will help to ensure no regressions or the issue is not re-introduced. If you need help
+with writing a test for your feature, please don't be shy and ask!
+
+
+Documentation
+-------------
+Up-to-date documentation makes all our lives easier. If you are adding a new feature, enhancing an existing feature, or
+fixing an issue, please add or modify the documentation as needed and include it with your pull request.

--- a/README.md
+++ b/README.md
@@ -45,6 +45,11 @@ npmRun {
 ```
 
 
+Contributing
+------------
+Before working on the code, if you plan to contribute changes, please read the [CONTRIBUTING](CONTRIBUTING.md) document.
+
+
 License
 -------
 This project is made available under the [Apache 2.0 License][license].


### PR DESCRIPTION
* was removed when updating to the new CLA process
* adding this version back that has no reference to PDFs
* this version only refers to the project's best practices (style, testing, docs, etc.)